### PR TITLE
Mavericks (10.9) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+go-osx-plist.test

--- a/convert.go
+++ b/convert.go
@@ -192,13 +192,13 @@ func convertTimeToCFDate(t time.Time) C.CFDateRef {
 	// truncate to milliseconds, to get a more predictable conversion
 	ms := int64(time.Duration(t.UnixNano()) / time.Millisecond * time.Millisecond)
 	nano := C.double(ms) / C.double(time.Second)
-	nano -= C.kCFAbsoluteTimeIntervalSince1970
+	nano -= C.double(C.kCFAbsoluteTimeIntervalSince1970)
 	return C.CFDateCreate(nil, C.CFAbsoluteTime(nano))
 }
 
 func convertCFDateToTime(cfDate C.CFDateRef) time.Time {
 	nano := C.double(C.CFDateGetAbsoluteTime(cfDate))
-	nano += C.kCFAbsoluteTimeIntervalSince1970
+	nano += C.double(C.kCFAbsoluteTimeIntervalSince1970)
 	// pull out milliseconds, to get a more predictable conversion
 	ms := int64(float64(C.round(nano * 1000)))
 	sec := ms / 1000


### PR DESCRIPTION
Hi Kevin,

I've been playing around with binary plists the last couple of days in Go, and came across this repo. Unfortunately, it doesn't work on Mavericks, so I've started work on fixing that.

I've coerced `kCFAbsoluteTimeIntervalSince1970` to a `double` because otherwise the code won't compile.

There's a failing tests now, which relates to converting invalid `CFString`s.

```
--- FAIL: TestCFString_Invalid (0.00 seconds)
    convert_test.go:67: failed on input: "hello\x00world". Output: "hello". Expected: "hello\x00world"
FAIL
exit status 1
FAIL    _/Users/jcf/Code/go-osx-plist   0.094s
```

I'm not sure why the string gets split on `\x00`. Any thoughts?
